### PR TITLE
chore: bump django from 4.2.24 to 4.2.25

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dj-database-url==2.3.0
-Django==4.2.24
+Django==4.2.25
 django-db-geventpool==4.0.1
 django-cors-headers==4.6.0
 django-picklefield==3.2


### PR DESCRIPTION
### Description
chore: bump django from 4.2.24 to 4.2.25

## Clickup
https://app.clickup.com/ 